### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/lipstick2vnc.spec
+++ b/rpm/lipstick2vnc.spec
@@ -17,7 +17,6 @@ BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  qt5-qtwayland-wayland_egl-devel
 BuildRequires:  oneshot
-BuildRequires:  systemd
 Requires:       oneshot
 Requires:       jolla-sessions-qt5 >= 1.2.7
 %{_oneshot_requires_post}


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>