### PR TITLE
Move lipstick2vnc to user session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 *.pro.user*
 *.o
+*.list
 moc_*.cpp
 Makefile
-RPMS/
-src/mervncserver
-documentation.list
+/RPMS/
+/installroot/
+/src/mervncserver
+/src/lipstick2vnc
+/src/qwayland-lipstick-recorder.cpp
+/src/qwayland-lipstick-recorder.h
+/src/wayland-lipstick-recorder-client-protocol.h
+/src/wayland-lipstick-recorder-protocol.c

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # A vncserver for Sailfish devices
+Don't install this package if you care about security. There is no protection in this VNC server.
+
 ## Build in Sailfish OS SDK for an armv7hl device
 * you need libVNCServer in the SDK, follow the instructions in the [libVNCServer README](https://github.com/mer-qa/libvncserver/blob/master/README.md)
 
@@ -23,34 +25,35 @@ There is no authendication! So connections are just accepted from usb network. S
 ## Debug on device
 If you want to run the server in the forground, to follow any output, you need to stop the *systemd* socket listener, see below.
 
-For all these commands you must be user **root**.
+For all these commands you must be user, not **root**.
 
 To verify the *systemd* socket listener is active:
 ```
-systemctl status vnc.socket
+systemctl --user status vnc.socket
 ```
 
 To restart the *systemd* socket listener:
 ```
-systemctl restart vnc.socket
+systemctl --user stop vnc.socket
+systemctl --user start vnc.socket
 ```
 
 To stop the *systemd* socket listener:
 ```
-systemctl stop vnc.socket
+systemctl --user stop vnc.socket
 ```
 
 To start the *systemd* socket listener:
 ```
-systemctl start vnc.socket
+systemctl --user start vnc.socket
 ```
 
-Follow log entries in the *systemd* journal, just for the VNC server:
+Follow log entries in the *systemd* journal, just for the VNC server, run this as **root**:
 ```
 journalctl -f -a /usr/bin/lipstick2vnc
 ```
 
 Verify if the server is running (just running/active when a client is connected):
 ```
-systemctl status vnc.service
+systemctl --user status vnc.service
 ```

--- a/data/vnc.service
+++ b/data/vnc.service
@@ -1,15 +1,8 @@
 [Unit]
 Description=VNC Per-Connection Server
-After=syslog.target
 
 [Service]
-Group=privileged
-Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/activeuser/dbus/user_bus_socket
-Environment=XDG_RUNTIME_DIR=/run/activeuser
-# Include common nemo project wide env settings
+# Include common nemo project wide env settings, e.g. LIPSTICK2VNC_OPTS
 EnvironmentFile=-/var/lib/environment/nemo/*.conf
 ExecStart=-/usr/bin/lipstick2vnc $LIPSTICK2VNC_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
-
-[Install]
-WantedBy=network.target

--- a/data/vnc.socket
+++ b/data/vnc.socket
@@ -4,6 +4,3 @@ Before=vnc.service
 [Socket]
 ListenStream=5900
 Accept=no
-
-[Install]
-WantedBy=sockets.target

--- a/lipstick2vnc.pro
+++ b/lipstick2vnc.pro
@@ -16,7 +16,7 @@ systemd_vnc.files = \
     data/vnc.socket \
     data/vnc.service
 
-systemd_vnc.path = /usr/lib/systemd/system/
+systemd_vnc.path = /usr/lib/systemd/user/
 
 oneshot.files = data/20-lipstick2vnc-configurator
 oneshot.path  = /usr/lib/oneshot.d/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,8 +115,6 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/100000/dbus/user_bus_socket", 0);
-
     ScreenToVnc screen2vnc(NULL, smoothScaling, scaleFactor, usec, buffers, processTimerInterval, doMouseHandler);
     if(!screen2vnc.m_allFine){
         LOG() << "something failed to initialize!";


### PR DESCRIPTION
To properly support multiple users, move lipstick2vnc to user session.
Privileged rights can not be obtained through invoker because that
breaks systemd socket activation. Instead this uses set GID bit.
Remove old code to set D-Bus socket path because that is now set
correctly by default. Get rid of /run/activeuser in vnc.service.